### PR TITLE
Remove dependency on nmath

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'geometry', github: 'netizer/geometry'
+
 group :test do
     gem 'rake'
     gem 'minitest'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'geometry', github: 'netizer/geometry'
+gem 'geometry', github: 'bfoz/geometry', ref: '3054ccba59f184c172be52a6f0b7cf4a33f617a5'
 
 group :test do
     gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,17 @@
+GIT
+  remote: git://github.com/netizer/geometry.git
+  revision: 493c43076f45b6888ac9f99f1e9018c2a5073de8
+  specs:
+    geometry (6.5)
+
 PATH
   remote: .
   specs:
     dxf (0.3.1)
-      geometry (~> 6.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    geometry (6.5)
     minitest (5.9.0)
     rake (11.2.2)
 
@@ -16,8 +20,9 @@ PLATFORMS
 
 DEPENDENCIES
   dxf!
+  geometry!
   minitest
   rake
 
 BUNDLED WITH
-   1.12.5
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: git://github.com/netizer/geometry.git
-  revision: 493c43076f45b6888ac9f99f1e9018c2a5073de8
+  remote: git://github.com/bfoz/geometry.git
+  revision: 3054ccba59f184c172be52a6f0b7cf4a33f617a5
+  ref: 3054ccba59f184c172be52a6f0b7cf4a33f617a5
   specs:
     geometry (6.5)
 
@@ -25,4 +26,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.0
+   1.16.6

--- a/dxf.gemspec
+++ b/dxf.gemspec
@@ -16,7 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'geometry', '~> 6.4'
-
   gem.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
## Quick fix

When this PR is accepted, I'll be able to update EDDiE so that it didn't depend on my own versions of `dxf-ruby` and `geometry`.

## Better approach

It would be better if https://github.com/bfoz/geometry would release a new version of the library, so we didn't have to depend on a particular github hash of the library. 

## Some background
Originally I set the dependency to my own clones because we wanted to get rid of `nmath` dependency (it caused errors when doing basic math operations, and the gem is not maintained anymore). Later on `bfoz/geometry` accepted my PR but a new version of the gem was not released yet, so we depend on a particular ref in the github repo. 